### PR TITLE
Feature/githubci

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -1,4 +1,4 @@
-name: Arduino Library CI
+name: Arduino-timer Library CI
 
 on: [pull_request, push, repository_dispatch]
 
@@ -24,6 +24,7 @@ jobs:
       run: python3 ci/build_platform.py main_platforms esp32 esp8266
       #run: python3 ci/build_platform.py main_platforms esp32 esp8266 nrf52840
 
+    # disabled for now.
     #- name: doxygen
       #env:
       #  GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -20,8 +20,9 @@ jobs:
       run: bash ci/actions_install.sh
 
     - name: test platforms
-      #run: python3 ci/build_platform.py main_platforms
-      run: python3 ci/build_platform.py main_platforms esp32 esp8266 nrf52840
+      run: python3 ci/build_platform.py main_platforms
+      run: python3 ci/build_platform.py esp32 esp8266
+      #run: python3 ci/build_platform.py nrf52840
 
     #- name: doxygen
       #env:

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -20,9 +20,9 @@ jobs:
       run: bash ci/actions_install.sh
 
     - name: test platforms
-      run: python3 ci/build_platform.py main_platforms
-      run: python3 ci/build_platform.py esp32 esp8266
-      #run: python3 ci/build_platform.py nrf52840
+      #run: python3 ci/build_platform.py main_platforms
+      run: python3 ci/build_platform.py main_platforms esp32 esp8266
+      #run: python3 ci/build_platform.py main_platforms esp32 esp8266 nrf52840
 
     #- name: doxygen
       #env:

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -1,0 +1,29 @@
+name: Arduino Library CI
+
+on: [pull_request, push, repository_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+      with:
+         repository: adafruit/ci-arduino
+         path: ci
+
+    - name: pre-install
+      run: bash ci/actions_install.sh
+
+    - name: test platforms
+      run: python3 ci/build_platform.py main_platforms
+
+    #- name: doxygen
+      #env:
+      #  GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
+      #  PRETTYNAME : "arduino-timer Library"
+      #run: bash ci/doxy_gen_and_deploy.sh

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: test platforms
       #run: python3 ci/build_platform.py main_platforms
-      run: python3 ci/build_platform.py all_platforms
+      run: python3 ci/build_platform.py main_platforms esp32 esp8266 nrf52840
 
     #- name: doxygen
       #env:

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -20,7 +20,8 @@ jobs:
       run: bash ci/actions_install.sh
 
     - name: test platforms
-      run: python3 ci/build_platform.py main_platforms
+      #run: python3 ci/build_platform.py main_platforms
+      run: python3 ci/build_platform.py all_platforms
 
     #- name: doxygen
       #env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# (borrowed from Adafruit_NeoPixel lib)
+#
+# Our handy .gitignore for automation ease
+Doxyfile*
+doxygen_sqlite3.db
+html


### PR DESCRIPTION
FYI here is a github action configuration.  It checks whether the **arduino-timer** library and example code will compile on various platforms.

It uses code in the  **adafruit/ci-arduino** repository to do the build.

This pull request is definitely an enhancement.  It may not be in a direction you wanted to go.  If that's the case, never mind, just reject it and move on.  

However if you were meaning to use continuous integration sometime and hadn't found the time to set it up, here's something that might help.

For more information, see [The Well-Automated Arduino Library](https://learn.adafruit.com/the-well-automated-arduino-library/repository)

Notes:
- Currently the **adafruit/ci-arduino** list of **main_platforms** does not include _ALL_ platforms by default.  This list is maintained by @adafruit, so may grow or shrink at times as platform support "starts working" for them.
- I added checks for **esp32** and **esp8266** platforms, since they seemed to build OK.  (these explicit additions may become redundant when they are get folded into **main_platforms** by default.
-  Support for **nrf52840** doesn't seem to be ready enough yet.
- I commented out doxygen support, as doxygen isn't used in this library (and it needs extra github build setup that I didn't get working)