### PR TITLE
src:arduino-timer: Remove WProgram.h include

### DIFF
--- a/src/arduino-timer.h
+++ b/src/arduino-timer.h
@@ -35,11 +35,7 @@
 #ifndef _CM_ARDUINO_TIMER_H__
 #define _CM_ARDUINO_TIMER_H__
 
-#if defined(ARDUINO) && ARDUINO >= 100
 #include <Arduino.h>
-#else
-#include <WProgram.h>
-#endif
 
 #ifndef TIMER_MAX_TASKS
     #define TIMER_MAX_TASKS 0x10


### PR DESCRIPTION
This header was renamed in Nov. 2011 and only Arduino IDE versions
prior to v1.0 used that name.

Signed-off-by: Sean Robinson <sean.robinson@scottsdalecc.edu>