### PR TITLE
src:arduino-timer: Cast t to Task, not uintptr_t

### DIFF
--- a/src/arduino-timer.h
+++ b/src/arduino-timer.h
@@ -94,7 +94,7 @@ class Timer {
         if (!task) return;
 
         timer_foreach_task(t) {
-            if (t->handler && (t->id ^ task) == (uintptr_t)t) {
+            if (t->handler && (t->id ^ task) == (Task)t) {
                 remove(t);
                 break;
             }


### PR DESCRIPTION
The typedef for Task was changed in the same commit where this cast was
added.  Probably just an oversight.

Signed-off-by: Sean Robinson <sean.robinson@scottsdalecc.edu>