### PR TITLE
Pj/update ci workflows

### DIFF
--- a/.github/workflows/aunit_tests.yml
+++ b/.github/workflows/aunit_tests.yml
@@ -5,10 +5,10 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build
       run: |

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - uses: actions/checkout@v3

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -10,8 +10,8 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v2
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
       with:
          repository: adafruit/ci-arduino
          path: ci


### PR DESCRIPTION
Github actions for unit tests and CI builds now showing some warnings about deprecated interfaces:

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/setup-python, actions/checkout, actions/checkout, actions/checkout, actions/checkoutNode.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/setup-python, actions/checkout, actions/checkout, actions/checkout, actions/checkout
```
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
This pull request updates script versions used for:

- Ubuntu version to "latest" instead of fixed at 18.04
- actions/checkout to v3
- actions/setup-python to v4

No need to rush a release yet as the old scripts still work -- but we probably want to release the change at a convenient time.