### PR TITLE
Pj/task collision test

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -20,8 +20,8 @@ jobs:
       run: bash ci/actions_install.sh
 
     - name: test platforms
-      #run: python3 ci/build_platform.py main_platforms
-      run: python3 ci/build_platform.py main_platforms esp32 esp8266
+      run: python3 ci/build_platform.py main_platforms
+      #run: python3 ci/build_platform.py main_platforms esp32 esp8266
       #run: python3 ci/build_platform.py main_platforms esp32 esp8266 nrf52840
 
     # disabled for now.

--- a/extras/tests/timerMultiCancelTest/Makefile
+++ b/extras/tests/timerMultiCancelTest/Makefile
@@ -1,0 +1,9 @@
+# See https://github.com/bxparks/UnixHostDuino for documentation about this
+# Makefile to compile and run Arduino programs natively on Linux or MacOS.
+#
+
+APP_NAME := timerMultiCancelTest
+ARDUINO_LIBS := AUnit arduino-timer
+CPPFLAGS += -Werror
+
+include $(UNIXHOSTDUINO)

--- a/extras/tests/timerMultiCancelTest/timerMultiCancelTest.ino
+++ b/extras/tests/timerMultiCancelTest/timerMultiCancelTest.ino
@@ -55,14 +55,14 @@ bool createTask(int index) {
     // cancel task in slot
     auto staleId = taskInfo.id;
     int beforeSize = (int)timer.size();
-    timer.cancel(taskInfo.id);
+    successful &= timer.cancel(taskInfo.id);
     int afterSize = (int)timer.size();
     successful &= (afterSize == beforeSize - 1);
     if (!successful) {
       Serial.println(F("could not cancel a task"));
     } else {
 
-      timer.cancel(staleId);  // double cancel should not hit another task
+      successful &= !timer.cancel(staleId);  // double cancel should not hit another task
       int afterSize2 = (int)timer.size();
       successful &= (afterSize2 == beforeSize - 1);
       if (!successful) {

--- a/extras/tests/timerMultiCancelTest/timerMultiCancelTest.ino
+++ b/extras/tests/timerMultiCancelTest/timerMultiCancelTest.ino
@@ -1,0 +1,173 @@
+// arduino-timer unit tests
+// timerMultiCancelTest.ino unit test
+// find regressions when:
+//     timer.cancel(...) is called twice and cancels an extra task
+//     timer.in/at/every(...) return task id 0 (should mean "not created")
+//     timer.in/at/every(...) return an in-use task id (1 id with 2 tasks)
+
+// Arduino "AUnit" library required
+
+// Required for UnixHostDuino emulation
+#include <Arduino.h>
+
+#if defined(UNIX_HOST_DUINO)
+#ifndef ARDUINO
+#define ARDUINO 100
+#endif
+#endif
+
+#include <AUnit.h>
+#include <arduino-timer.h>
+
+//#define DEBUG
+#ifdef DEBUG
+#define DEBUG_PRINT(x) Serial.print(x)
+#define DEBUG_PRINTLN(x) Serial.println(x)
+#else
+#define DEBUG_PRINT(x)
+#define DEBUG_PRINTLN(x)
+#endif
+
+auto timer = timer_create_default();  // create a timer with default settings
+
+// a generic task
+bool dummyTask(void*) {
+  //digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN));  // toggle the LED
+  return true;  // repeat? true
+}
+
+struct TaskInfo {
+  Timer<>::Task id;  // id to use to cancel
+  unsigned long instanceNumber;
+};
+
+static const int numTaskIds = 20;
+
+TaskInfo tasksToCancel[numTaskIds] = { 0 };
+
+unsigned long creationAttempts = 0;
+
+bool createTask(int index) {
+  bool successful = true;  // OK so far
+  TaskInfo& taskInfo = tasksToCancel[index];
+
+  if (taskInfo.id != (Timer<>::Task)NULL) {
+    // cancel task in slot
+    auto staleId = taskInfo.id;
+    int beforeSize = (int)timer.size();
+    timer.cancel(taskInfo.id);
+    int afterSize = (int)timer.size();
+    successful &= (afterSize == beforeSize - 1);
+    if (!successful) {
+      Serial.println(F("could not cancel a task"));
+    } else {
+
+      timer.cancel(staleId);  // double cancel should not hit another task
+      int afterSize2 = (int)timer.size();
+      successful &= (afterSize2 == beforeSize - 1);
+      if (!successful) {
+        Serial.println(F("second cancel removed another task"));
+      }
+    }
+  }
+
+  auto newId = timer.every(250, dummyTask);
+  ++creationAttempts;
+
+  static size_t timerSize = 0;
+  auto newSize = timer.size();
+  if (timerSize != newSize) {
+    timerSize = newSize;
+    DEBUG_PRINT(F("Timer now has "));
+    DEBUG_PRINT(timerSize);
+    DEBUG_PRINTLN(F(" tasks"));
+  }
+
+  if (newId == 0) {
+    Serial.print(F("timer task creation failure on creation number "));
+    Serial.println(creationAttempts);
+    successful = false;
+
+  } else {
+
+    // check for collisions before saving taskInfo
+    for (int i = 0; i < numTaskIds; i++) {
+      const TaskInfo& ti = tasksToCancel[i];
+      if (ti.id == newId) {
+        successful = false;
+        Serial.print(F("COLLISION FOUND! instance number: "));
+        Serial.print(creationAttempts);
+        Serial.print(F(" hash "));
+        Serial.print(F("0x"));
+        Serial.print((size_t)newId, HEX);
+        Serial.print(F(" "));
+        Serial.print((size_t)newId, BIN);
+
+        Serial.print(F(" matches hash for instance number: "));
+        Serial.println(ti.instanceNumber);
+      }
+    }
+    taskInfo.id = newId;
+    taskInfo.instanceNumber = creationAttempts;
+
+    static const unsigned long reportCountTime = 10000;
+    if (creationAttempts % reportCountTime == 0) {
+      DEBUG_PRINT(creationAttempts / 1000);
+      DEBUG_PRINTLN(F("k tasks created."));
+    }
+  }
+  return successful;
+}
+
+test(timerMultiCancel) {
+  timer.cancel();  // ensure timer starts empty
+  assertEqual((int)timer.size(), 0);
+  creationAttempts = 0;
+
+  // timer capacity is 0x10 -- stay below
+  // load up some static tasks
+  for (int i = 0; i < 6; i++) {
+    assertTrue(createTask(i));
+  }
+
+  assertEqual((int)timer.size(), 6);
+
+  // cancel/recreate tasks
+  //for (unsigned long groups = 0; groups < 30000UL; groups++) {
+  unsigned long groups = 0;
+  do {
+    //for (unsigned long groups = 0; creationAttempts < 0x10010; groups++) {  // trouble over 64k tasks?
+    for (int i = 9; i < 0x10; i++) {
+      assertTrue(createTask(i));
+      if (groups > 0) {
+        // should be steady-state task size now
+        assertEqual((int)timer.size(), 13);
+      }
+    }
+    groups++;
+    //}
+  } while (creationAttempts < 0x10010);  // no trouble over 64K tasks?
+
+  Serial.print(creationAttempts);
+  Serial.println(F(" tasks created."));
+}
+
+void sketch(void) {
+  Serial.println();
+  Serial.println(F("Running " __FILE__ ", Built " __DATE__));
+}
+
+void setup() {
+  ::delay(1000UL);         // wait for stability on some boards to prevent garbage Serial
+  Serial.begin(115200UL);  // ESP8266 default of 74880 not supported on Linux
+  while (!Serial)
+    ;  // for the Arduino Leonardo/Micro only
+  sketch();
+}
+
+void loop() {
+  // Should get:
+  // TestRunner summary:
+  //    <n> passed, <n> failed, <n> skipped, <n> timed out, out of <n> test(s).
+  aunit::TestRunner::run();
+}

--- a/extras/tests/unitTest/unitTest.ino
+++ b/extras/tests/unitTest/unitTest.ino
@@ -262,6 +262,7 @@ test(timer_cancel) {
     // assert task has not run
     assertEqual(task.runs, 0UL);
 
+    auto stale_r = r;
     const bool success = timer.cancel(r);
 
     // assert task found
@@ -283,6 +284,10 @@ test(timer_cancel) {
 
     // assert task not found
     assertEqual(fail, false);
+
+    // stale task pointer has nothing to cancel
+    const bool stale_cancel_fail = timer.cancel(stale_r);
+    assertEqual(stale_cancel_fail, false);
 }
 
 test(timer_cancel_all) {
@@ -373,23 +378,23 @@ test(timer_size) {
 
     Timer<0x2, CLOCK::millis, Task *> timer;
 
-    assertEqual(timer.size(), 0UL);
+    assertEqual((unsigned long) timer.size(), 0UL);
 
     auto t = make_task();
 
     auto r = timer.in(0UL, handler, &t);
 
     assertNotEqual((unsigned long)r, 0UL);
-    assertEqual(timer.size(), 1UL);
+    assertEqual((unsigned long) timer.size(), 1UL);
 
     r = timer.in(0UL, handler, &t);
 
     assertNotEqual((unsigned long)r, 0UL);
-    assertEqual(timer.size(), 2UL);
+    assertEqual((unsigned long) timer.size(), 2UL);
 
     timer.cancel();
 
-    assertEqual(timer.size(), 0UL);
+    assertEqual((unsigned long) timer.size(), 0UL);
 }
 
 test(timer_empty) {

--- a/src/arduino-timer.h
+++ b/src/arduino-timer.h
@@ -91,7 +91,7 @@ class Timer {
     {
         struct task * const t = static_cast<struct task * const>(task);
 
-        if (t) {
+        if (t && (tasks <= t) && (t < tasks + max_tasks) && (t->handler)) {
             remove(t);
             task = static_cast<Task>(NULL);
             return true;

--- a/src/arduino-timer.h
+++ b/src/arduino-timer.h
@@ -91,7 +91,7 @@ class Timer {
     {
         struct task * const t = static_cast<struct task * const>(task);
 
-        if (t && (tasks <= t) && (t < tasks + max_tasks) && (t->handler)) {
+        if (t && (tasks <= t) && (t < tasks + max_tasks) && t->handler) {
             remove(t);
             task = static_cast<Task>(NULL);
             return true;


### PR DESCRIPTION
I decided to create a pull request for my regression test of timer ID collisions, cancel() etc.

... and, I think I discovered a regression.

Now that `timer.cancel(anId)` returns a `bool`, AND timers no longer use a counter to randomize Task values, timer.cancel() will always find a Task to cancel, _even if it is an empty task_.

So... `timer.cancel(anId)` always returns `true`... even if anId is cancelled twice in a row.